### PR TITLE
Hotfix

### DIFF
--- a/CommonCode.ps1
+++ b/CommonCode.ps1
@@ -54,7 +54,7 @@ Function RunSQLQuery($Query){
     If ($DatabaseType -eq "MYSQL") {
         MySQLQuery($Query)
     } ElseIf ($DatabaseType -eq "MSSQL"){
-        MySQLQuery($Query)
+        MSSQLQuery($Query)
     } Else {
         Out-Null
     }
@@ -86,9 +86,8 @@ Function MySQLQuery($Query) {
 Function MSSQLQuery($Query) {
 	$Today = (Get-Date).ToString("yyyyMMdd")
 	$DBErrorLog = "$PSScriptRoot\$Today-DBError.log"
-    $ConnectionString = "Data Source=" + $SQLHost + ";port=" + $SQLPort + ";uid=" + $SQLAdminUserName + ";password=" + $SQLAdminPassword + ";Initial Catalog=" + $SQLDatabase
+    $ConnectionString = "Data Source=" + $SQLHost + "," + $SQLPort + ";uid=" + $SQLAdminUserName + ";password=" + $SQLAdminPassword + ";Initial Catalog=" + $SQLDatabase
 	Try {
-		[void][System.Reflection.Assembly]::LoadWithPartialName("MySql.Data")
 		$Connection = New-Object System.Data.SqlClient.SQLConnection($connectionString)
 		$Connection.Open()
 		$Command = New-Object System.Data.SqlClient.SqlCommand($Query, $Connection)


### PR DESCRIPTION
    Hotfix:
    - Run MSSQL calling wrong function
    - MSSQL connection string builder passing MSSQL Server port wrong way.
    Both at CommonCode.ps1

Sorry, but I updated my powershell scripts just now and saw that I had two small mistakes. I made these corrections, tested the three scripts that are scheduled in the task scheduler and apparently worked without problems. Follow the fixes.